### PR TITLE
fix: 나의 루틴 조회 시 데이터가 없으면 빈 배열 전송

### DIFF
--- a/src/models/routineDao.js
+++ b/src/models/routineDao.js
@@ -119,6 +119,7 @@ const routinesByUser = async (userId) => {
       routines.id AS routineId, 
       routines.name AS routineName,
       JSON_ARRAYAGG(exercises.name) AS exerciseNames,
+      JSON_ARRAYAGG(exercises.set_counts) AS setCounts, 
       TIME_FORMAT(
         SEC_TO_TIME(
           SUM(exercises.duration_in_seconds_per_set * exercises.set_counts)

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,7 +1,6 @@
 const exerciseService = require("./exerciseService");
 const userService = require("./userService");
 const routineService = require("./routineService");
-const userService = require("./userService");
 
 module.exports = {
   exerciseService,

--- a/src/services/routineService.js
+++ b/src/services/routineService.js
@@ -59,14 +59,10 @@ const updateCompletedExerciseStatus = async (id, exerciseIds) => {
     utils.throwError(400, "INVALID_INPUT");
 
   await routineDao.updateCompletedExerciseStatusbyRoutineId(id, exerciseIds);
+};
 
 const routinesByUser = async (userId) => {
   const findUserRoutines = await routineDao.routinesByUser(userId);
-  if (!findUserRoutines) {
-    const error = new Error("NO_CUSTOM_ROUTINES");
-    error.status = 400;
-    throw error;
-  }
   return findUserRoutines;
 };
 


### PR DESCRIPTION
## 1. 본 PR이 우리 팀의 웹 서비스 제품성에 어떠한 기여를 하였고, <br> 사용자에게 어떠한 기대효과를 전달하는지 작성해주세요.

- 내 PR이 제품 내 어떠한 기능적인 배경/전후맥락 가운데 개발되었나요?
나의 루틴 조회 시 데이터가 없으면 빈 배열 전송
나의 루틴 조회할 때 setCounts도 전송

<br />

## 2. 이 브랜치에서 어떤 내용을 개발했는지 큰 제목과 상세 내역을 적어주세요.

routineService 수정
routineDao 수정

<br />

## 3. 개발한 화면을 캡쳐해서 첨부 해 주세요.

<br />

<img width="1294" alt="image" src="https://github.com/wecode-bootcamp-korea/49-3rd-OneMore-backend/assets/139973591/fbe07b53-5870-4eba-a03d-56b32d97b424">
<img width="1294" alt="image" src="https://github.com/wecode-bootcamp-korea/49-3rd-OneMore-backend/assets/139973591/29616bb6-adbf-49e3-9f7e-7e95ab79876c">



<br />

## 4. 이 브랜치에서 개발하면서 느꼇던 개발 성장포인트를 적어주세요.

  <br />
